### PR TITLE
Make volume icons brighter, with more contrast on dark background

### DIFF
--- a/icons/audio-volume-high.svg
+++ b/icons/audio-volume-high.svg
@@ -3,9 +3,9 @@
 
   <polygon 
     points="38,15 40,15 40,85 38,85 15,60 4,60 4,40 15,40 "
-    style="fill: black; fill-opacity: 0.7; stroke: black;stroke-width: 2;"/> 
-  <path d="m 51,24 c 16,15 16,38 1,53" style="fill:none;stroke:#20631E;stroke-width:7"/>
-  <path d="m 62,14 c 37,38 1,73 1,73" style="fill:none;stroke:#20631E;stroke-width:7"/>
-  <path d="M 72,5 C 120,54 73,97 73,97" style="fill:none;stroke:#20631E;stroke-width:7"/>
+    style="fill: #959595; stroke: black;stroke-width: 2;"/> 
+  <path d="m 51,24 c 16,15 16,38 1,53" style="fill:none;stroke:#007B00;stroke-width:7"/>
+  <path d="m 62,14 c 37,38 1,73 1,73" style="fill:none;stroke:#007B00;stroke-width:7"/>
+  <path d="M 72,5 C 120,54 73,97 73,97" style="fill:none;stroke:#007B00;stroke-width:7"/>
 
 </svg>

--- a/icons/audio-volume-low.svg
+++ b/icons/audio-volume-low.svg
@@ -3,7 +3,7 @@
 
   <polygon 
     points="38,15 40,15 40,85 38,85 15,60 4,60 4,40 15,40 "
-    style="fill: black; fill-opacity: 0.7; stroke: black;stroke-width: 2;"/> 
-  <path d="m 51,24 c 16,15 16,38 1,53" style="fill:none;stroke:#20631E;stroke-width:7"/>
+    style="fill: #959595; stroke: black;stroke-width: 2;"/> 
+  <path d="m 51,24 c 16,15 16,38 1,53" style="fill:none;stroke:#007B00;stroke-width:7"/>
 
 </svg>

--- a/icons/audio-volume-medium.svg
+++ b/icons/audio-volume-medium.svg
@@ -3,8 +3,8 @@
 
   <polygon 
     points="38,15 40,15 40,85 38,85 15,60 4,60 4,40 15,40 "
-    style="fill: black; fill-opacity: 0.7; stroke: black;stroke-width: 2;"/> 
-  <path d="m 51,24 c 16,15 16,38 1,53" style="fill:none;stroke:#20631E;stroke-width:7"/>
-  <path d="m 62,14 c 37,38 1,73 1,73" style="fill:none;stroke:#20631E;stroke-width:7"/>
+    style="fill: #959595; stroke: black;stroke-width: 2;"/> 
+  <path d="m 51,24 c 16,15 16,38 1,53" style="fill:none;stroke:#007B00;stroke-width:7"/>
+  <path d="m 62,14 c 37,38 1,73 1,73" style="fill:none;stroke:#007B00;stroke-width:7"/>
 
 </svg>

--- a/icons/audio-volume-muted.svg
+++ b/icons/audio-volume-muted.svg
@@ -3,7 +3,7 @@
 
   <polygon 
      points="38,15 40,15 40,85 38,85 15,60 4,60 4,40 15,40 "
-     style="fill: black; fill-opacity: 0.7; stroke: black;stroke-width: 2;"/> 
+     style="fill: #959595; stroke: black;stroke-width: 2;"/> 
   <path style="fill:#FF3D3D;stroke:#730000;stroke-width:3;" d="M 54,25 46,34 62,50 46,67 54,75 71,59 87,75 95,67 80,50 95,33 87,25 71,41 z"/>
 
 </svg>


### PR DESCRIPTION
![bright](https://user-images.githubusercontent.com/1471149/210964284-52b013ed-aab5-4ea0-aae2-bcbcec484ef4.png)
![dark](https://user-images.githubusercontent.com/1471149/210964287-1551e86d-7805-4177-89d3-990bd27f692d.png)

See puppylinux-woof-CE/woof-CE#3811.